### PR TITLE
release: integrate xyz

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -7,11 +7,18 @@
   "scripts": {
     "build": "babel src/ -d dist/",
     "lint": "eslint src/ test/",
+    "release": "xyz --repo git@github.com:xodio/hm-def.git --increment",
     "test": "mocha test/**/*.spec.js"
   },
   "keywords": [],
   "author": "XOD LLC",
   "license": "MIT",
+  "files": [
+    "/dist/",
+    "/LICENSE",
+    "/README.md",
+    "/package.json"
+  ],
   "dependencies": {
     "hm-parser": "^0.1.5",
     "ramda": "^0.24.1",
@@ -28,6 +35,7 @@
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
     "mocha": "^3.2.0",
-    "sanctuary-type-classes": "^7.1.1"
+    "sanctuary-type-classes": "^7.1.1",
+    "xyz": "3.0.x"
   }
 }


### PR DESCRIPTION
Using [xyz][1] to release new versions of this package will remove many sources of human error from the process. It will also make releasing new versions very convenient, as one will simply run one of the following commands:

``` console
$ npm run release major
```

``` console
$ npm run release minor
```

``` console
$ npm run release patch
```

This will:

1.  Verify that the current branch is `master`.
2.  Verify that the working directory contains no unstaged changes.
3.  Present a confirmation prompt.
4.  Verify that `npm test` exits successfully.
5.  Update the `"version"` field in __package.json__.
6.  Commit the change to __package.json__ with the message `Version X.Y.Z`.
7.  Create an annotated tag named `vX.Y.Z` pointing to the commit.
8.  Push the commit and the tag—atomically—to GitHub.
9.  Run `npm publish`.

I've used xyz countless times over the past four years. It's rock solid. It's not Windows-compatible, but I imagine that's not a problem.


[1]: https://github.com/davidchambers/xyz
