### PR TITLE
update Sanctuary dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "fantasy-land": "^3.5.0",
     "hm-parser": "^0.1.5",
     "mem": "^4.0.0",
-    "sanctuary": "^1.1.0",
-    "sanctuary-def": "^0.19.0",
+    "sanctuary": "^2.0.0",
+    "sanctuary-def": "^0.20.0",
     "sanctuary-show": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fantasy-land": "^3.5.0",
     "hm-parser": "^0.1.5",
     "mem": "^4.0.0",
-    "sanctuary": "^1.0.0",
+    "sanctuary": "^1.1.0",
     "sanctuary-def": "^0.19.0",
     "sanctuary-show": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsverify": "^0.8.3",
     "mocha": "^5.2.0",
     "sanctuary-style": "^2.0.0",
-    "sanctuary-type-classes": "^10.0.0",
+    "sanctuary-type-classes": "^11.0.0",
     "xyz": "3.0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "fantasy-land": "^3.5.0",
     "hm-parser": "^0.1.5",
     "mem": "^4.0.0",
-    "sanctuary": "^2.0.0",
-    "sanctuary-def": "^0.20.0",
+    "sanctuary": "^2.0.1",
+    "sanctuary-def": "^0.20.1",
     "sanctuary-show": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "fantasy-land": "^3.5.0",
     "hm-parser": "^0.1.5",
     "mem": "^4.0.0",
-    "sanctuary": "^0.15.0",
-    "sanctuary-def": "^0.18.1",
+    "sanctuary": "^1.0.0",
+    "sanctuary-def": "^0.19.0",
     "sanctuary-show": "^1.0.0"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "jsverify": "^0.8.3",
     "mocha": "^5.2.0",
     "sanctuary-style": "^2.0.0",
-    "sanctuary-type-classes": "^9.0.0",
+    "sanctuary-type-classes": "^10.0.0",
     "xyz": "3.0.x"
   }
 }

--- a/src/signature.js
+++ b/src/signature.js
@@ -190,7 +190,7 @@ export const resolve = $ => {
     (t.name)
     (t.url)
     (t.supertypes)
-    (t._test)
+    (t._test ([]))
     (t.extractors.$1);
 
   //    fromBinaryType :: Type -> (Type -> Type -> Type)
@@ -198,7 +198,7 @@ export const resolve = $ => {
     (t.name)
     (t.url)
     (t.supertypes)
-    (t._test)
+    (t._test ([]))
     (t.extractors.$1)
     (t.extractors.$2);
 

--- a/src/signature.js
+++ b/src/signature.js
@@ -189,16 +189,18 @@ export const resolve = $ => {
   const fromUnaryType = t => $.UnaryType
     (t.name)
     (t.url)
+    (t.supertypes)
     (t._test)
-    (t.types.$1.extractor);
+    (t.extractors.$1);
 
   //    fromBinaryType :: Type -> (Type -> Type -> Type)
   const fromBinaryType = t => $.BinaryType
     (t.name)
     (t.url)
+    (t.supertypes)
     (t._test)
-    (t.types.$1.extractor)
-    (t.types.$2.extractor);
+    (t.extractors.$1)
+    (t.extractors.$2);
 
   //    constructType :: (Array Type) -> Type -> Type
   const constructType = argTypes => t => {
@@ -217,7 +219,7 @@ export const resolve = $ => {
   };
 
   // Helper Type to wipe out thunks
-  const Thunk = $.NullaryType ('hm-def/Thunk') ('') (S.K (false));
+  const Thunk = $.NullaryType ('hm-def/Thunk') ('') ([]) (S.K (false));
 
   //    convertType :: SignatureEntry -> Reader (TypeMap Type)
   const convertType = memoize (entry => cond ([

--- a/test/def.spec.js
+++ b/test/def.spec.js
@@ -4,8 +4,6 @@ import Z from 'sanctuary-type-classes';
 import {assert} from 'chai';
 import {create} from '../src/index';
 
-const hasProp = p => x => x[p] !== undefined;
-
 const $Map = $.BinaryType
   ('Map')
   ('someurl')

--- a/test/def.spec.js
+++ b/test/def.spec.js
@@ -9,6 +9,7 @@ const hasProp = p => x => x[p] !== undefined;
 const $Map = $.BinaryType
   ('Map')
   ('someurl')
+  ([])
   (S.is ($.Object))
   (S.keys)
   (S.values);
@@ -16,7 +17,8 @@ const $Map = $.BinaryType
 const $Wrapper = $.UnaryType
   ('Wrapper')
   ('someurl')
-  (S.allPass ([S.is ($.Object), hasProp ('value')]))
+  ([])
+  (x => S.is ($.Object) (x) && S.isJust (S.get (S.complement (S.is ($.Undefined))) ('value') (x)))
   (S.pipe ([S.prop ('value'), S.of (Array)]));
 
 const def = create ({
@@ -66,7 +68,7 @@ describe ('def', () => {
     const cube = x => x * x * x;
 
     assert.deepEqual (foo (cube) ([1, 2, 3]), [1, 8, 27]);
-    assert.throws (() => foo (cube) ('im-not-an-unary-type'), 'Type-class constraint violation');
+    assert.throws (() => foo (cube) ('im-not-an-unary-type'), 'The value at position 1 is not a member of ‘f a’');
   });
 
   it ('should work with type class constraints', () => {
@@ -85,8 +87,8 @@ describe ('def', () => {
       (S.prop ('value'));
 
     assert.equal (foo ({value: 10}), 10);
-    assert.throws (() => foo ({}), 'The value at position 1 is not a member of ‘Wrapper Number’');
-    assert.throws (() => foo (null), 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => foo ({}), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => foo (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
     assert.throws (() => foo ({value: 'hello'}), 'The value at position 1 is not a member of ‘Number’');
 
     const bar = def
@@ -94,8 +96,8 @@ describe ('def', () => {
       (x => { x.value = x.value.toString (); return x; });
 
     assert.deepEqual (bar ({value: 10}), {value: '10'});
-    assert.throws (() => bar ({}), 'The value at position 1 is not a member of ‘Wrapper Number’');
-    assert.throws (() => bar (null), 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => bar ({}), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => bar (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
     assert.throws (() => bar ({value: 'hello'}), 'The value at position 1 is not a member of ‘Number’');
   });
 
@@ -106,7 +108,7 @@ describe ('def', () => {
 
     assert.deepEqual (foo ({a: 5, b: 7}), {a: '5', b: '7'});
     assert.throws (() => foo ({a: false}), 'The value at position 1 is not a member of ‘Number’');
-    assert.throws (() => foo (null), 'The value at position 1 is not a member of ‘Map String Number’');
+    assert.throws (() => foo (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map String Number’');
 
     const bar = def
       ('bar :: Map String (Map String Number) -> Map String Boolean')
@@ -117,15 +119,15 @@ describe ('def', () => {
       ])));
 
     assert.deepEqual (bar ({a: {x: 0, y: 1}, b: {x: 1, y: 3}}), {a: true, b: false});
-    assert.throws (() => bar ({a: false}), 'The value at position 1 is not a member of ‘Map String Number’');
-    assert.throws (() => bar (null), 'The value at position 1 is not a member of ‘Map String (Map String Number)’');
+//    assert.throws (() => bar ({a: false}), 'The value at position 1 is not a member of ‘Map String Number’'); // FIXME not thrown anymore !
+    assert.throws (() => bar (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map String (Map String Number)’');
 
     const buzz = def
       ('buzz :: Map a b -> Map a a')
       (S.map (x => x.toString ()));
 
     assert.deepEqual (buzz ({a: 1, b: 2}), {a: '1', b: '2'});
-    assert.throws (() => buzz (null), 'The value at position 1 is not a member of ‘Map a b’');
+    assert.throws (() => buzz (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map a b’');
   });
 
   it ('should work with higher order functions', () => {

--- a/test/def.spec.js
+++ b/test/def.spec.js
@@ -17,8 +17,8 @@ const $Map = $.BinaryType
 const $Wrapper = $.UnaryType
   ('Wrapper')
   ('someurl')
-  ([])
-  (x => S.is ($.Object) (x) && S.isJust (S.get (S.complement (S.is ($.Undefined))) ('value') (x)))
+  ([$.Object])
+  (x => 'value' in x)
   (S.pipe ([S.prop ('value'), S.of (Array)]));
 
 const def = create ({

--- a/test/def.spec.js
+++ b/test/def.spec.js
@@ -87,8 +87,8 @@ describe ('def', () => {
       (S.prop ('value'));
 
     assert.equal (foo ({value: 10}), 10);
-    assert.throws (() => foo ({}), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
-    assert.throws (() => foo (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => foo ({}), 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => foo (null), 'The value at position 1 is not a member of ‘Wrapper Number’');
     assert.throws (() => foo ({value: 'hello'}), 'The value at position 1 is not a member of ‘Number’');
 
     const bar = def
@@ -96,8 +96,8 @@ describe ('def', () => {
       (x => { x.value = x.value.toString (); return x; });
 
     assert.deepEqual (bar ({value: 10}), {value: '10'});
-    assert.throws (() => bar ({}), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
-    assert.throws (() => bar (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => bar ({}), 'The value at position 1 is not a member of ‘Wrapper Number’');
+    assert.throws (() => bar (null), 'The value at position 1 is not a member of ‘Wrapper Number’');
     assert.throws (() => bar ({value: 'hello'}), 'The value at position 1 is not a member of ‘Number’');
   });
 
@@ -108,7 +108,7 @@ describe ('def', () => {
 
     assert.deepEqual (foo ({a: 5, b: 7}), {a: '5', b: '7'});
     assert.throws (() => foo ({a: false}), 'The value at position 1 is not a member of ‘Number’');
-    assert.throws (() => foo (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map String Number’');
+    assert.throws (() => foo (null), 'The value at position 1 is not a member of ‘Map String Number’');
 
     const bar = def
       ('bar :: Map String (Map String Number) -> Map String Boolean')
@@ -119,15 +119,15 @@ describe ('def', () => {
       ])));
 
     assert.deepEqual (bar ({a: {x: 0, y: 1}, b: {x: 1, y: 3}}), {a: true, b: false});
-//    assert.throws (() => bar ({a: false}), 'The value at position 1 is not a member of ‘Map String Number’'); // FIXME not thrown anymore !
-    assert.throws (() => bar (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map String (Map String Number)’');
+    assert.throws (() => bar ({a: false}), 'The value at position 1 is not a member of ‘Map String Number’');
+    assert.throws (() => bar (null), 'The value at position 1 is not a member of ‘Map String (Map String Number)’');
 
     const buzz = def
       ('buzz :: Map a b -> Map a a')
       (S.map (x => x.toString ()));
 
     assert.deepEqual (buzz ({a: 1, b: 2}), {a: '1', b: '2'});
-    assert.throws (() => buzz (null), Error); // FIXME message 'The value at position 1 is not a member of ‘Map a b’');
+    assert.throws (() => buzz (null), 'The value at position 1 is not a member of ‘Map a b’');
   });
 
   it ('should work with higher order functions', () => {

--- a/test/signature.spec.js
+++ b/test/signature.spec.js
@@ -1,14 +1,14 @@
 import S from 'sanctuary';
 import $ from 'sanctuary-def';
 import Z from 'sanctuary-type-classes';
+import show from 'sanctuary-show';
 import {assert} from 'chai';
 import {resolve} from '../src/signature';
-import show from 'sanctuary-show';
 
 // assertSameTypes :: [Type] -> [Type] -> Undefined !
 const assertSameTypes = actual => expected => {
   if (!(S.equals (actual) (expected))) { // Array and Type are both Setoid providing equals()
-    assert.equal (show (actual), show (expected), "S.equals"); // assert.equal() because assert.isOk() does not diff actual/expected
+    assert.equal (show (actual), show (expected), 'S.equals'); // assert.equal() because assert.isOk() does not diff actual/expected
     assert.fail (); // final failure in the hypothetical case that show() would return same strings for different types
   }
 };

--- a/test/signature.spec.js
+++ b/test/signature.spec.js
@@ -3,19 +3,14 @@ import $ from 'sanctuary-def';
 import Z from 'sanctuary-type-classes';
 import {assert} from 'chai';
 import {resolve} from '../src/signature';
+import show from 'sanctuary-show';
 
 // assertSameType :: Type -> Type -> Undefined !
 const assertSameType = actual => expected => {
-  return assert.isOk (S.equals (actual) (expected)) // FIXME directly replace assertTypePairs( S.zip (types) (..) ) by S.equals (types) (expecteds)
-/*
-  assert.strictEqual (actual.name, expected.name);
-  assert.strictEqual (actual.type, expected.type);
-  assert.deepEqual (actual.keys, expected.keys);
-  assert.deepEqual (actual.url, expected.url);
-  expected.keys.forEach (key => {
-    assertSameType (actual.types[key].type) (expected.types[key].type);
-  });
-*/
+  if (!(S.equals (actual) (expected))) { // Type is Setoid providing equals()
+    assert.equal (show (actual), show (expected), "S.equals"); // assert.equal() because assert.isOk() does not diff actual/expected
+    assert.fail(); // final failure in the hypothetical case that show() would return same strings for different types
+  }
 };
 
 const assertTypePairs = xs => xs.forEach

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,23 +2944,15 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanctuary-def@0.20.0, sanctuary-def@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.20.0.tgz#bcecc9a1469c025467ea31f0ec6228ed56962bb3"
-  integrity sha512-BjDwAq+4aHZhKyOR35oVfVkCOLfKMOVw6UqQfkzL/Ul5G290J0nITSmnM9fP6EaH2rV/0quR7wgoCgX5Um5YGg==
+sanctuary-def@0.20.1, sanctuary-def@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.20.1.tgz#172f70a694a0ae6d3944c95cda6a18744c4eeac7"
+  integrity sha512-WdOg5uDpqvplADyUb7pyDMNaT73TUzsE7VdKnZsEz6CwsNh46NSQAWZXM0i6IiqItnDtILkL5RGd4SGAvmjxLw==
   dependencies:
-    sanctuary-either "1.1.0"
+    sanctuary-either "1.2.0"
     sanctuary-show "1.0.x"
     sanctuary-type-classes "11.0.x"
     sanctuary-type-identifiers "2.0.x"
-
-sanctuary-either@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-either/-/sanctuary-either-1.1.0.tgz#9d45b344d870c16fc72f574feec1744dc50f4e1f"
-  integrity sha512-tQewdQTPKzuJGahV5iuILJM96I+AfIFn3vpi0s2FhHYENbRqO4JeFSWLNT1mJ9SupSJBopgWefWeUjq/ZKfdtg==
-  dependencies:
-    sanctuary-show "1.0.x"
-    sanctuary-type-classes "10.0.0"
 
 sanctuary-either@1.2.0:
   version "1.2.0"
@@ -2996,13 +2988,6 @@ sanctuary-style@^2.0.0:
   resolved "https://registry.yarnpkg.com/sanctuary-style/-/sanctuary-style-2.0.0.tgz#83d023a340641bcc1d27acee013c098b12075586"
   integrity sha512-5g3UnBDY3419ipokMa/PXY9DM7XVU7sUMq3RMHRKnbqS9KYKWYvysljb8/rHi+bWut5n1omWEQJEyKUHY+482w==
 
-sanctuary-type-classes@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-10.0.0.tgz#25126f009348101dbe627c7b7efb7c6f63f792b1"
-  integrity sha512-h5Q1VkW/CmVbmoWDf6HdsgJbx5gc3n6R5lRzzKRssYSkghmqEuAr+0ThJs/bqJK8aiQwh3N2PXP4ZppYEDlSdg==
-  dependencies:
-    sanctuary-type-identifiers "2.0.1"
-
 sanctuary-type-classes@11.0.0, sanctuary-type-classes@11.0.x, sanctuary-type-classes@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-11.0.0.tgz#f7f752a846aad057d894183a20169bc593ddb039"
@@ -3027,12 +3012,12 @@ sanctuary-type-identifiers@2.0.1, sanctuary-type-identifiers@2.0.x:
   resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
   integrity sha1-/FJM9t2Szr/LsN2VCe/xkxWaIO0=
 
-sanctuary@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-2.0.0.tgz#71c2e8af7cfe034ece2c7a932232ba917a03dd0f"
-  integrity sha512-FYjhCKBS7meY4Lrjsx7CL+2+qnCsgUqJUvFYoLU7ahiGM8LqTOkhAtdGZGG+bhCIP0iCEfDWRq35pQJTfmtFrg==
+sanctuary@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-2.0.1.tgz#cf19548bb8df2f52c9367faf8f7a7a4cf52af0ee"
+  integrity sha512-CQWjFRzSYrq8g16RCdfV4v1iJwyRRw3dhLizA/rKkKSu1L+5tTlBjQuZl25mKSd4S5oLdVTIJ1RlVktvns9R9g==
   dependencies:
-    sanctuary-def "0.20.0"
+    sanctuary-def "0.20.1"
     sanctuary-either "1.2.0"
     sanctuary-maybe "1.2.0"
     sanctuary-pair "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3027,10 +3027,10 @@ sanctuary-type-identifiers@2.0.1, sanctuary-type-identifiers@2.0.x:
   resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
   integrity sha1-/FJM9t2Szr/LsN2VCe/xkxWaIO0=
 
-sanctuary@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-1.0.0.tgz#ecddfd453290b4e269fdc4bb8314e3c25febc79d"
-  integrity sha512-H+C80DadljM0gyWe5Y3R8bDIDW8MU8/XBg0h0V2zwusmljRAVrBQshd6XU3zFxk+lHj04e9xoUvBscRfl8vO8g==
+sanctuary@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-1.1.0.tgz#b1e66dd0746377e89bfd1ec0916e010e3f4dc4d3"
+  integrity sha512-GnZoSJ0tlNneowz+shFYLd1+wQ0g9bR3TeBbDi0rwEdpspu6mQPxEghskJrGww2rBNjyPclEL5pzNC0oCUYHAQ==
   dependencies:
     sanctuary-def "0.19.0"
     sanctuary-either "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,7 +2996,7 @@ sanctuary-style@^2.0.0:
   resolved "https://registry.yarnpkg.com/sanctuary-style/-/sanctuary-style-2.0.0.tgz#83d023a340641bcc1d27acee013c098b12075586"
   integrity sha512-5g3UnBDY3419ipokMa/PXY9DM7XVU7sUMq3RMHRKnbqS9KYKWYvysljb8/rHi+bWut5n1omWEQJEyKUHY+482w==
 
-sanctuary-type-classes@10.0.0, sanctuary-type-classes@10.0.x, sanctuary-type-classes@^10.0.0:
+sanctuary-type-classes@10.0.0, sanctuary-type-classes@10.0.x:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-10.0.0.tgz#25126f009348101dbe627c7b7efb7c6f63f792b1"
   integrity sha512-h5Q1VkW/CmVbmoWDf6HdsgJbx5gc3n6R5lRzzKRssYSkghmqEuAr+0ThJs/bqJK8aiQwh3N2PXP4ZppYEDlSdg==
@@ -3009,6 +3009,13 @@ sanctuary-type-classes@9.0.0:
   integrity sha512-rFW27f3D622kxKravpGU9OjWn66fnDjDjGPvoYo4hEoBg2ocypvp0R9cs0YovKL3jTO+PTceUBh5tYZ+l9ay3g==
   dependencies:
     sanctuary-type-identifiers "1.0.x"
+
+sanctuary-type-classes@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-11.0.0.tgz#f7f752a846aad057d894183a20169bc593ddb039"
+  integrity sha512-J9vfS19C9TSd0pIxz7dza0krxUGoo7LYdwQzkmO7zEsbzmPEwbB3HByLgN/zI+QYd0m08IdohAzYJSAd89Fdqg==
+  dependencies:
+    sanctuary-type-identifiers "2.0.1"
 
 sanctuary-type-identifiers@1.0.x:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,17 +2944,17 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanctuary-def@0.18.1, sanctuary-def@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.18.1.tgz#580af82a3fbbd651e8dddc0ab34b11727ef63b5f"
-  integrity sha512-Ltu/gU5ZskRln8NI6YJru5JbpkcMe4XqFx5zJMZysTKPmOVkETys5eVvZmclNLzPNrOIPvqBGJtD/D2q9yvP/A==
+sanctuary-def@0.19.0, sanctuary-def@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.19.0.tgz#84dd038f723512168028654dd89563cbbf3a34af"
+  integrity sha512-1ZJX4LC3Kh4B9bnGGCN8qQS7GrHltLtibQnsaFqaoUpKIT4qCfUuCy/Beke352E948+lmquowyDfkMHtZ/0m3w==
   dependencies:
     sanctuary-either "1.0.x"
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "9.0.x"
+    sanctuary-type-classes "10.0.x"
     sanctuary-type-identifiers "2.0.x"
 
-sanctuary-either@1.0.0, sanctuary-either@1.0.x:
+sanctuary-either@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-either/-/sanctuary-either-1.0.0.tgz#b6041e54c639700048be757ba4d6c026c2c2f67c"
   integrity sha512-j4WAlwILU83wawXJQCSh5kVK27gxOykMuCfUfUOba/qUcFE+FxwHkt7lnHVYDjt7jG9SENe8bTQzPH/Zmhy3Ag==
@@ -2962,21 +2962,29 @@ sanctuary-either@1.0.0, sanctuary-either@1.0.x:
     sanctuary-show "1.0.x"
     sanctuary-type-classes "9.0.0"
 
-sanctuary-maybe@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-maybe/-/sanctuary-maybe-1.0.0.tgz#03cd226d933ec89270e4495a965733390e843afc"
-  integrity sha512-4TUjIxznxTZ1dh8Zw4PRhaVkzY8KIZ4GGsOXBytOSV83MRRGkuz7wJHj3bfh2i9lOekbjf0Oal6v7IF6uDiYvg==
+sanctuary-either@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-either/-/sanctuary-either-1.1.0.tgz#9d45b344d870c16fc72f574feec1744dc50f4e1f"
+  integrity sha512-tQewdQTPKzuJGahV5iuILJM96I+AfIFn3vpi0s2FhHYENbRqO4JeFSWLNT1mJ9SupSJBopgWefWeUjq/ZKfdtg==
   dependencies:
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "9.0.0"
+    sanctuary-type-classes "10.0.0"
 
-sanctuary-pair@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-pair/-/sanctuary-pair-1.0.0.tgz#eaf8121f0ba3064e5e0b09bb624bc3885209886a"
-  integrity sha512-fqXCO6boMLW7ZHrjc573u5maNdytIrNxeaotBBGrvbEVqiNeA6VH4eGARMLTCRdgOtW94aF5EUkBZCzvXLSujQ==
+sanctuary-maybe@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-maybe/-/sanctuary-maybe-1.1.0.tgz#b4b6807d949dc56fbc30834aebb925de1a05cddf"
+  integrity sha512-MwHsfddXxfn7Ywy9hiRIA/+lbJBUKeKI/cSHwTKkbLkelSBhSpBgZZI4giSZRwbP9OpxOpbkS+rFc//+HCVwdw==
   dependencies:
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "9.0.0"
+    sanctuary-type-classes "10.0.0"
+
+sanctuary-pair@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-pair/-/sanctuary-pair-1.1.0.tgz#5a0d3d54ba2a1ebcd3a0bf3a2bc7c86c085a36ed"
+  integrity sha512-lr+lTHZCzKD3PAS8YHB0YhVLsKIRIzoeIg5SBWYquXgabVdVShOT+J+7E3cg4v+FOpgN1HWguYQcbJczCSEVyQ==
+  dependencies:
+    sanctuary-show "1.0.x"
+    sanctuary-type-classes "10.0.0"
 
 sanctuary-show@1.0.0, sanctuary-show@1.0.x, sanctuary-show@^1.0.0:
   version "1.0.0"
@@ -2988,7 +2996,14 @@ sanctuary-style@^2.0.0:
   resolved "https://registry.yarnpkg.com/sanctuary-style/-/sanctuary-style-2.0.0.tgz#83d023a340641bcc1d27acee013c098b12075586"
   integrity sha512-5g3UnBDY3419ipokMa/PXY9DM7XVU7sUMq3RMHRKnbqS9KYKWYvysljb8/rHi+bWut5n1omWEQJEyKUHY+482w==
 
-sanctuary-type-classes@9.0.0, sanctuary-type-classes@9.0.x, sanctuary-type-classes@^9.0.0:
+sanctuary-type-classes@10.0.0, sanctuary-type-classes@10.0.x, sanctuary-type-classes@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-10.0.0.tgz#25126f009348101dbe627c7b7efb7c6f63f792b1"
+  integrity sha512-h5Q1VkW/CmVbmoWDf6HdsgJbx5gc3n6R5lRzzKRssYSkghmqEuAr+0ThJs/bqJK8aiQwh3N2PXP4ZppYEDlSdg==
+  dependencies:
+    sanctuary-type-identifiers "2.0.1"
+
+sanctuary-type-classes@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-9.0.0.tgz#b44741ca67fa650cbd314e1ad318d730ce1309a4"
   integrity sha512-rFW27f3D622kxKravpGU9OjWn66fnDjDjGPvoYo4hEoBg2ocypvp0R9cs0YovKL3jTO+PTceUBh5tYZ+l9ay3g==
@@ -3005,17 +3020,17 @@ sanctuary-type-identifiers@2.0.1, sanctuary-type-identifiers@2.0.x:
   resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
   integrity sha1-/FJM9t2Szr/LsN2VCe/xkxWaIO0=
 
-sanctuary@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-0.15.0.tgz#a4b9bf7a43bad928dce3e7aa590fbf30681b9ebd"
-  integrity sha512-cyrFHazodEFlv6qVX/+qujO+jly2MXRMyNXR61jaqJG42JlCJnKpgQGvebYINaiRUbZ+P5Dr2Ai3Tg+vzNYCUw==
+sanctuary@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-1.0.0.tgz#ecddfd453290b4e269fdc4bb8314e3c25febc79d"
+  integrity sha512-H+C80DadljM0gyWe5Y3R8bDIDW8MU8/XBg0h0V2zwusmljRAVrBQshd6XU3zFxk+lHj04e9xoUvBscRfl8vO8g==
   dependencies:
-    sanctuary-def "0.18.1"
-    sanctuary-either "1.0.0"
-    sanctuary-maybe "1.0.0"
-    sanctuary-pair "1.0.0"
+    sanctuary-def "0.19.0"
+    sanctuary-either "1.1.0"
+    sanctuary-maybe "1.1.0"
+    sanctuary-pair "1.1.0"
     sanctuary-show "1.0.0"
-    sanctuary-type-classes "9.0.0"
+    sanctuary-type-classes "10.0.0"
     sanctuary-type-identifiers "2.0.1"
 
 sax@^1.2.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,23 +2944,15 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sanctuary-def@0.19.0, sanctuary-def@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.19.0.tgz#84dd038f723512168028654dd89563cbbf3a34af"
-  integrity sha512-1ZJX4LC3Kh4B9bnGGCN8qQS7GrHltLtibQnsaFqaoUpKIT4qCfUuCy/Beke352E948+lmquowyDfkMHtZ/0m3w==
+sanctuary-def@0.20.0, sanctuary-def@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-def/-/sanctuary-def-0.20.0.tgz#bcecc9a1469c025467ea31f0ec6228ed56962bb3"
+  integrity sha512-BjDwAq+4aHZhKyOR35oVfVkCOLfKMOVw6UqQfkzL/Ul5G290J0nITSmnM9fP6EaH2rV/0quR7wgoCgX5Um5YGg==
   dependencies:
-    sanctuary-either "1.0.x"
+    sanctuary-either "1.1.0"
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "10.0.x"
+    sanctuary-type-classes "11.0.x"
     sanctuary-type-identifiers "2.0.x"
-
-sanctuary-either@1.0.x:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-either/-/sanctuary-either-1.0.0.tgz#b6041e54c639700048be757ba4d6c026c2c2f67c"
-  integrity sha512-j4WAlwILU83wawXJQCSh5kVK27gxOykMuCfUfUOba/qUcFE+FxwHkt7lnHVYDjt7jG9SENe8bTQzPH/Zmhy3Ag==
-  dependencies:
-    sanctuary-show "1.0.x"
-    sanctuary-type-classes "9.0.0"
 
 sanctuary-either@1.1.0:
   version "1.1.0"
@@ -2970,21 +2962,29 @@ sanctuary-either@1.1.0:
     sanctuary-show "1.0.x"
     sanctuary-type-classes "10.0.0"
 
-sanctuary-maybe@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-maybe/-/sanctuary-maybe-1.1.0.tgz#b4b6807d949dc56fbc30834aebb925de1a05cddf"
-  integrity sha512-MwHsfddXxfn7Ywy9hiRIA/+lbJBUKeKI/cSHwTKkbLkelSBhSpBgZZI4giSZRwbP9OpxOpbkS+rFc//+HCVwdw==
+sanctuary-either@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-either/-/sanctuary-either-1.2.0.tgz#3126196a2067ea4a9b1de6b6c4c045504059a44b"
+  integrity sha512-CFUK0OOGAe+t+Ct4yVLfkJPABIkplCvIgCOFIJZ+lIMNAeJrSaVacrZVqRErt4YKzDs42ZXecAEpoDL8rRAfsQ==
   dependencies:
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "10.0.0"
+    sanctuary-type-classes "11.0.0"
 
-sanctuary-pair@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-pair/-/sanctuary-pair-1.1.0.tgz#5a0d3d54ba2a1ebcd3a0bf3a2bc7c86c085a36ed"
-  integrity sha512-lr+lTHZCzKD3PAS8YHB0YhVLsKIRIzoeIg5SBWYquXgabVdVShOT+J+7E3cg4v+FOpgN1HWguYQcbJczCSEVyQ==
+sanctuary-maybe@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-maybe/-/sanctuary-maybe-1.2.0.tgz#e994825d62f6d5a3c60771e859261b08c517acc5"
+  integrity sha512-SH4dkyrruJe84/q8YMjc6kWyGbqPH6clM6yfJ/iosQZm+bGK2XPgcPs1yDN0U0zm1JzJ563zdwn64W+aMw5CDw==
   dependencies:
     sanctuary-show "1.0.x"
-    sanctuary-type-classes "10.0.0"
+    sanctuary-type-classes "11.0.0"
+
+sanctuary-pair@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-pair/-/sanctuary-pair-1.2.0.tgz#2538dbdac011594fd601ca1112e83cb5083bc865"
+  integrity sha512-bPu+uFxFE2RP3hLlC6SRMsm4A2aEwHkDwHWuvGzHxYaclGnHCrHy0ykRTuR0Pgqy/ZlWl6zy+8Tek3jME3du6A==
+  dependencies:
+    sanctuary-show "1.0.x"
+    sanctuary-type-classes "11.0.0"
 
 sanctuary-show@1.0.0, sanctuary-show@1.0.x, sanctuary-show@^1.0.0:
   version "1.0.0"
@@ -2996,10 +2996,17 @@ sanctuary-style@^2.0.0:
   resolved "https://registry.yarnpkg.com/sanctuary-style/-/sanctuary-style-2.0.0.tgz#83d023a340641bcc1d27acee013c098b12075586"
   integrity sha512-5g3UnBDY3419ipokMa/PXY9DM7XVU7sUMq3RMHRKnbqS9KYKWYvysljb8/rHi+bWut5n1omWEQJEyKUHY+482w==
 
-sanctuary-type-classes@10.0.0, sanctuary-type-classes@10.0.x:
+sanctuary-type-classes@10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-10.0.0.tgz#25126f009348101dbe627c7b7efb7c6f63f792b1"
   integrity sha512-h5Q1VkW/CmVbmoWDf6HdsgJbx5gc3n6R5lRzzKRssYSkghmqEuAr+0ThJs/bqJK8aiQwh3N2PXP4ZppYEDlSdg==
+  dependencies:
+    sanctuary-type-identifiers "2.0.1"
+
+sanctuary-type-classes@11.0.0, sanctuary-type-classes@11.0.x, sanctuary-type-classes@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-11.0.0.tgz#f7f752a846aad057d894183a20169bc593ddb039"
+  integrity sha512-J9vfS19C9TSd0pIxz7dza0krxUGoo7LYdwQzkmO7zEsbzmPEwbB3HByLgN/zI+QYd0m08IdohAzYJSAd89Fdqg==
   dependencies:
     sanctuary-type-identifiers "2.0.1"
 
@@ -3009,13 +3016,6 @@ sanctuary-type-classes@9.0.0:
   integrity sha512-rFW27f3D622kxKravpGU9OjWn66fnDjDjGPvoYo4hEoBg2ocypvp0R9cs0YovKL3jTO+PTceUBh5tYZ+l9ay3g==
   dependencies:
     sanctuary-type-identifiers "1.0.x"
-
-sanctuary-type-classes@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/sanctuary-type-classes/-/sanctuary-type-classes-11.0.0.tgz#f7f752a846aad057d894183a20169bc593ddb039"
-  integrity sha512-J9vfS19C9TSd0pIxz7dza0krxUGoo7LYdwQzkmO7zEsbzmPEwbB3HByLgN/zI+QYd0m08IdohAzYJSAd89Fdqg==
-  dependencies:
-    sanctuary-type-identifiers "2.0.1"
 
 sanctuary-type-identifiers@1.0.x:
   version "1.0.0"
@@ -3027,17 +3027,17 @@ sanctuary-type-identifiers@2.0.1, sanctuary-type-identifiers@2.0.x:
   resolved "https://registry.yarnpkg.com/sanctuary-type-identifiers/-/sanctuary-type-identifiers-2.0.1.tgz#fc524cf6dd92cebfcbb0dd9509eff193159a20ed"
   integrity sha1-/FJM9t2Szr/LsN2VCe/xkxWaIO0=
 
-sanctuary@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-1.1.0.tgz#b1e66dd0746377e89bfd1ec0916e010e3f4dc4d3"
-  integrity sha512-GnZoSJ0tlNneowz+shFYLd1+wQ0g9bR3TeBbDi0rwEdpspu6mQPxEghskJrGww2rBNjyPclEL5pzNC0oCUYHAQ==
+sanctuary@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sanctuary/-/sanctuary-2.0.0.tgz#71c2e8af7cfe034ece2c7a932232ba917a03dd0f"
+  integrity sha512-FYjhCKBS7meY4Lrjsx7CL+2+qnCsgUqJUvFYoLU7ahiGM8LqTOkhAtdGZGG+bhCIP0iCEfDWRq35pQJTfmtFrg==
   dependencies:
-    sanctuary-def "0.19.0"
-    sanctuary-either "1.1.0"
-    sanctuary-maybe "1.1.0"
-    sanctuary-pair "1.1.0"
+    sanctuary-def "0.20.0"
+    sanctuary-either "1.2.0"
+    sanctuary-maybe "1.2.0"
+    sanctuary-pair "1.2.0"
     sanctuary-show "1.0.0"
-    sanctuary-type-classes "10.0.0"
+    sanctuary-type-classes "11.0.0"
     sanctuary-type-identifiers "2.0.1"
 
 sax@^1.2.4:


### PR DESCRIPTION
I couldn't use hm-def with latest Sanctuary, so I updated all the libs to their latest version, with the help of @davidchambers :
- sanctuary ^2.0.1
- sanctuary-def ^0.20.1
- sanctuary-type-classes ^11.0.0

I also had to fix tests, and replaced assertType() by assertTypes():
- now use Setoid's equals() to compare Array of Type without looking at their internals.
- removed S.zip(), because it only compares based on the length of the shortest array (ex: test is considered as valid if first array is empty and second is not).