### PR TITLE
docs: fix simple typo, constaints -> constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ provided by
 [sanctuary-type-classes](https://github.com/sanctuary-js/sanctuary-type-classes)
 and you can create your own.
 
-To use HM definitions with type class constaints you should provide `typeClasses`
+To use HM definitions with type class constraints you should provide `typeClasses`
 option with classes you’d like to use later:
 
 ```javascript


### PR DESCRIPTION
There is a small typo in README.md.

Should read `constraints` rather than `constaints`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md